### PR TITLE
Set up container scanning workflow

### DIFF
--- a/.github/workflows/04-01-scan-containers4_1.yml
+++ b/.github/workflows/04-01-scan-containers4_1.yml
@@ -590,8 +590,8 @@ jobs:
   check-spot-failures:
     needs: [setup-matrix, build-and-scan]
     runs-on: ubuntu-latest
-    # Only check for failures if we were using spot VMs and some jobs failed
-    if: ${{ always() && needs.setup-matrix.outputs.use_spot == 'true' && contains(needs.build-and-scan.result, 'failure') }}
+    # Only check for failures if we were using spot VMs and some jobs failed or were cancelled
+    if: ${{ always() && needs.setup-matrix.outputs.use_spot == 'true' && (contains(needs.build-and-scan.result, 'failure') || contains(needs.build-and-scan.result, 'cancelled')) }}
     outputs:
       failed-matrix: ${{ steps.failed.outputs.matrix }}
       has-failures: ${{ steps.failed.outputs.has-failures }}


### PR DESCRIPTION
The check-spot-failures job was only triggering on 'failure' results, but spot VM evictions and job timeouts result in 'cancelled' status. This caused cancelled scans to not retry on regular VMs.

Updated the condition to handle both failures and cancellations, ensuring that evicted or timed-out spot VM scans will properly trigger retry logic on regular VM instances.

Fixes issue where Development scan was cancelled (likely eviction or timeout) but never retried on a non-spot instance.